### PR TITLE
First commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,20 @@ at the OS level.
 
 ## Requirements ##
 
-None.
+This role makes use of the [`community.general.json_query` Ansible
+filter](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#selecting-json-data-json-queries),
+which requires that the [`jmespath` Python
+package](https://pypi.org/project/jmespath/) be installed on the local
+host.
 
 ## Role Variables ##
 
-None.
+* `cert_url` - the URL where the DHS certificate p7b bundle can be
+  downloaded.  Defaults to "https://pki.treas.gov/dhsca_fullpath.p7b".
+* `single_cert_filename_prefix` - the prefix to use when creating the
+  individual certificate files extracted from the DHS certificate p7b
+  bundle.  If the prefix is "zz-" then individual certificate files
+  will be named "zz-00", "zz-01", etc.  Defaults to "dhs-cert-".
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-dhs-certificates.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-dhs-certificates/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-dhs-certificates.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-dhs-certificates/context:python)
 
-This is a skeleton project that can be used to quickly get a new
-[cisagov](https://github.com/cisagov) Ansible role GitHub project
-started.  This skeleton project contains
-[licensing information](LICENSE), as well as
-[pre-commit hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for an Ansible role.
+This is an Ansible role for configuring trust of DHS CA certificates
+at the OS level.
 
 ## Requirements ##
 
@@ -33,15 +28,8 @@ Here's how to use it in a playbook:
   become: yes
   become_method: sudo
   roles:
-    - skeleton
+    - dhs_certificates
 ```
-
-## New Repositories from a Skeleton ##
-
-Please see our [Project Setup guide](https://github.com/cisagov/development-guide/tree/develop/project_setup)
-for step-by-step instructions on how to start a new repository from
-a skeleton. This will save you time and effort when configuring a
-new repository!
 
 ## Contributing ##
 
@@ -63,4 +51,4 @@ with this waiver of copyright interest.
 
 ## Author Information ##
 
-First Last - <first.last@trio.dhs.gov>
+Shane Frasier - <jeremy.frasier@trio.dhs.gov>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,13 @@
+# The filename to use for the cer bundle (translated from the p7b
+# bundle)
+cer_filename: dhsca.cer
+
+# The URL where the DHS PKI bundle can be obtained
+cert_url: https://pki.treas.gov/dhsca_fullpath.p7b
+
+# The filename to use for the p7b bundle (downloaded from treas.gov)
+p7b_filename: dhsca.p7b
+
+# The filename prefix to use for the individual certificate files
+# (extracted from the cer bundle)
+single_cert_filename_prefix: dhs-cert-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Update certificate trust
+  ansible.builtin.shell: "{{ update_ca_trust_command }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,12 @@
 ---
 galaxy_info:
-  author: First Last
-  description: Skeleton Ansible role
+  author: Shane Frasier
+  description: Configure trust of DHS CA certificates at the OS level
   company: CISA Cyber Assessments
   galaxy_tags:
-    - skeleton
+    - certificates
+    - cisa
+    - dhs
   license: CC0
   # With the release of version 2.10, Ansible finally correctly
   # identifies Kali Linux as being the Kali distribution of the Debian
@@ -32,6 +34,6 @@ galaxy_info:
       versions:
         - bionic
         - focal
-  role_name: skeleton
+  role_name: dhs_certificates
 
 dependencies: []

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,7 +12,32 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("x", [True])
-def test_packages(host, x):
-    """Run a dummy test, just to show what one would look like."""
-    assert x
+@pytest.mark.parametrize("pkg_name", ["ca-certificates", "openssl"])
+def test_packages(host, pkg_name):
+    """Verify that all expected packages were installed."""
+    assert host.package(pkg_name).is_installed
+
+
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        "dhs-cert-00",
+        "dhs-cert-01",
+        "dhs-cert-02",
+        "dhs-cert-03",
+        "dhs-cert-04",
+    ],
+)
+def test_cert_files(host, file_name):
+    """Verify that all expected certificate files were installed."""
+    distribution = host.system_info.distribution
+    if distribution in ["amzn", "fedora"]:
+        path = "/etc/pki/ca-trust/source/anchors/"
+    elif distribution in ["debian", "kali", "ubuntu"]:
+        path = "/usr/local/share/ca-certificates/"
+    f = host.file(path + file_name)
+    assert f.exists
+    assert f.is_file
+    assert f.user == "root"
+    assert f.group == "root"
+    assert f.mode == 0o400

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+jmespath
 setuptools
 wheel

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
         url: "{{ cert_url }}"
 
     - name: Massage the DHS certificate bundle into the desired format
-      command:
+      ansible.builtin.command:
         cmd: >
           /usr/bin/openssl pkcs7 -print_certs
           -inform der -in /tmp/{{ p7b_filename }}
@@ -33,7 +33,7 @@
     # Debian is pretty picky about having a single certificate per
     # file
     - name: Split the cert file into multiple certs
-      command:
+      ansible.builtin.command:
         chdir: /tmp
         cmd: >
           /usr/bin/csplit --prefix {{ single_cert_filename_prefix }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,62 @@
 ---
-# tasks file for skeleton
+- name: Load var file specific to the OS type
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      paths:
+        - "{{ role_path }}/vars"
+
+- name: Install required system packages
+  ansible.builtin.package:
+    name: "{{ package_names }}"
+
+- name: Grab and pre-process the DHS certificate bundle
+  block:
+    - name: Grab DHS certificate bundle
+      ansible.builtin.get_url:
+        dest: /tmp/{{ p7b_filename }}
+        mode: 0600
+        url: "{{ cert_url }}"
+
+    - name: Massage the DHS certificate bundle into the desired format
+      command:
+        cmd: >
+          /usr/bin/openssl pkcs7 -print_certs
+          -inform der -in /tmp/{{ p7b_filename }}
+          -out /tmp/{{ cer_filename }}
+        creates: /tmp/{{ cer_filename }}
+
+    # Debian is pretty picky about having a single certificate per
+    # file
+    - name: Split the cert file into multiple certs
+      command:
+        chdir: /tmp
+        cmd: >
+          /usr/bin/csplit --prefix {{ single_cert_filename_prefix }}
+          --elide-empty-files --quiet
+          /tmp/{{ cer_filename }} /subject/ "{*}"
+        creates: /tmp/{{ single_cert_filename_prefix }}00
+
+- name: Copy the DHS certificates to the appropriate directory
+  block:
+    - name: Collect the names of all the certificate files that were previously split out
+      ansible.builtin.find:
+        paths:
+          - /tmp
+        patterns:
+          - "{{ single_cert_filename_prefix }}*"
+      register: find_result
+
+    - name: Copy the DHS certificates to the appropriate directory
+      ansible.builtin.copy:
+        dest: "{{ certificate_dir }}"
+        mode: 0600
+        remote_src: yes
+        src: "{{ item }}"
+      loop: "{{ find_result | community.general.json_query('files[*].path') }}"
+      notify:
+        - Update certificate trust

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
     - name: Copy the DHS certificates to the appropriate directory
       ansible.builtin.copy:
         dest: "{{ certificate_dir }}"
-        mode: 0600
+        mode: 0400
         remote_src: yes
         src: "{{ item }}"
       loop: "{{ find_result | community.general.json_query('files[*].path') }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,12 @@
+---
+# The packages necessary to install ca-certificates
+package_names:
+  - ca-certificates
+  - openssl
+
+# The directory where trusted certificates are to be copied
+certificate_dir: /usr/local/share/ca-certificates
+
+# The command used to update the CA trust, including the full path to
+# the executable
+update_ca_trust_command: /usr/sbin/update-ca-certificates

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,12 @@
+---
+# The necessary packages to install
+package_names:
+  - ca-certificates
+  - openssl
+
+# The directory where trusted certificates are to be copied
+certificate_dir: /etc/pki/ca-trust/source/anchors
+
+# The command used to update the CA trust, including the full path to
+# the executable
+update_ca_trust_command: /bin/update-ca-trust extract


### PR DESCRIPTION
## 🗣 Description ##

This pull request contains the first commits to create an Ansible role that installs and trusts the DHS certificate bundle.

## 💭 Motivation and context ##

Our local instances running the Tanium client require these certificates in order to communicate securely with the VENOM Tanium server.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
