### PR TITLE
Adjust test code to handle most recent DHS certificate bundle

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -25,7 +25,6 @@ def test_packages(host, pkg_name):
         "dhs-cert-01",
         "dhs-cert-02",
         "dhs-cert-03",
-        "dhs-cert-04",
     ],
 )
 def test_cert_files(host, file_name):


### PR DESCRIPTION
## 🗣 Description ##

This pull request alters the Molecule test code to expect four certificates from the DHS CA bundle, not five.

## 💭 Motivation and context ##

The DHS certificate bundle downloaded from [here](https://pki.treas.gov/dhsca_fullpath.p7b) now contains only four certificates; it used to contain five.  This was resulting in [Molecule test failures across all platforms](https://github.com/cisagov/ansible-role-dhs-certificates/actions/runs/15940023471).

It looks like this change happened between three and nine days ago.

## 🧪 Testing ##

All automated tests now pass; they do not without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
